### PR TITLE
fix: Fix disconnected error for chat

### DIFF
--- a/cocotalk/src/store/module/chat.js
+++ b/cocotalk/src/store/module/chat.js
@@ -234,6 +234,9 @@ const chat = {
 		SET_CONNECTION(state, payload) {
 			state.socket.client = payload;
 		},
+		UPDATE_MESSAGE_BUNDLE_ID(state, payload) {
+			state.socket.recentMessageBundleId = payload.nextMessageBundleId;
+		},
 	},
 	actions: {
 		changePage: function (context, payload) {
@@ -383,6 +386,9 @@ const chat = {
 				// });
 				// context.commit("SET_CHATLIST", res.data.data);
 			});
+		},
+		updateMessageBundleId(context, payload) {
+			context.commit("UPDATE_MESSAGE_BUNDLE_ID", payload);
 		},
 	},
 	modules: {},

--- a/cocotalk/src/views/Chat.vue
+++ b/cocotalk/src/views/Chat.vue
@@ -177,7 +177,7 @@ export default {
 						const payload = {
 							nextMessageBundleId: receivedMessage.messageBundleId,
 						};
-						this.$store.dispatch("chat/getChat", payload, { root: true });
+						this.$store.dispatch("chat/updateMessageBundleId", payload, { root: true });
 					});
 					// 채팅방 초대 - 이전의 Join과 다름. 좀 더 생각해보기
 					// const msg = {


### PR DESCRIPTION
- [ ] New Feature
- [x] 버그 수정
- [ ] 그 외

## 설명(Description)
* 잘 되던 채팅에서 메세지를 보내면 disconnect되는 에러 해결
   => 현재 마지막 메세지의 bundleId를 업데이트 해주는 vuex actions와 채팅방 목록의 bundleIds의 마지막 항목으로 업데이트 해주는 함수를 분리하여 해결하였다. 같은 결과를 내는 것으로 보이나 이후 연결되는 작업이 달라지기 때문의 향후의 안정성에서도 분리하는 것이 타당하다 생각해 분리하였다.