### PR TITLE
Feature/chat-list

### DIFF
--- a/cocotalk/src/components/modals/AddFriendModal.vue
+++ b/cocotalk/src/components/modals/AddFriendModal.vue
@@ -29,7 +29,7 @@
         </div>
         <div v-if="friendInfo" class="row" style="justify-content: right">
           <Button v-if="friendInfo.type == 0" text="1:1 채팅" width="80px" height="30px" />
-          <Button v-else-if="friendInfo.type == 2 || friendInfo.type == 1" text="친구추가" width="80px" height="30px" @click.native="addFriend" />
+          <Button v-else-if="friendInfo.type == 1 || friendInfo.type == 2" text="친구추가" width="80px" height="30px" @click.native="addFriend" />
           <Button v-else-if="friendInfo.type == 3" text="나와의 채팅" width="100px" height="30px" />
         </div>
         <!-- <div v-else class="row" style="justify-content: right" @click="getFriendInfo">

--- a/cocotalk/src/main.js
+++ b/cocotalk/src/main.js
@@ -11,8 +11,8 @@ moment.locale("ko");
 Vue.use(VueMoment, { moment });
 
 new Vue({
-	router,
-	store,
-	InfiniteLoading,
-	render: (h) => h(App),
+  router,
+  store,
+  InfiniteLoading,
+  render: (h) => h(App),
 }).$mount("#app");

--- a/cocotalk/src/store/module/chat.js
+++ b/cocotalk/src/store/module/chat.js
@@ -44,6 +44,9 @@ const chat = {
     UPDATE_MESSAGE_BUNDLE_ID(state, payload) {
       state.chatInfo.nextMessageBundleId = payload.nextMessageBundleId;
     },
+    UPDATE_MESSAGE_BUNDLE_COUNT(state, recentMessageBundleCount) {
+      state.chatInfo.recentMessageBundleCount = recentMessageBundleCount;
+    },
   },
   actions: {
     // 페이지 전환
@@ -72,6 +75,9 @@ const chat = {
     },
     updateMessageBundleId(context, payload) {
       context.commit("UPDATE_MESSAGE_BUNDLE_ID", payload);
+    },
+    updateMessageBundleCount(context, recentMessageBundleCount) {
+      context.commit("UPDATE_MESSAGE_BUNDLE_COUNT", recentMessageBundleCount);
     },
   },
   modules: {},

--- a/cocotalk/src/store/module/userStore.js
+++ b/cocotalk/src/store/module/userStore.js
@@ -1,6 +1,6 @@
-import router from "../../router";
-import store from "../../store";
-import axios from "../../utils/axios";
+import router from "@/router";
+import store from "@/store";
+import axios from "@/utils/axios";
 import createPersistedState from "vuex-persistedstate";
 
 const userStore = {

--- a/cocotalk/src/views/ChatRoom.vue
+++ b/cocotalk/src/views/ChatRoom.vue
@@ -172,7 +172,13 @@ export default {
         console.log("채팅내역 가져오기");
         let chatData = res.data.data;
         this.chatMessages = chatData.messageList;
+        chatData.room.messageBundleIds = chatData.room.messageBundleIds.slice(1, -1).split(", ");
         this.roomInfo = chatData.room;
+        // 새로 받은 최신 bundleId 업데이트
+        const payload = {
+          nextMessageBundleId: this.roomInfo.messageBundleIds[this.roomInfo.messageBundleIds.length - 1],
+        };
+        this.$store.dispatch("chat/updateMessageBundleId", payload, { root: true });
         let members = chatData.room.members;
         members.forEach((e) => {
           this.roomMemberIds.push(e.userId);
@@ -196,7 +202,7 @@ export default {
             const receivedMessage = JSON.parse(res.body);
             this.chatMessages.push(receivedMessage.message);
             console.log(receivedMessage);
-            // 새로 메세지가 들어올 경우 마지막 메세지의 BundleId 저장
+            // 새로 메세지가 들어올 경우 마지막 메세지의 BundleId로 업데이트
             const payload = {
               nextMessageBundleId: receivedMessage.bundleInfo.nextMessageBundleId,
             };

--- a/cocotalk/src/views/ChatRoom.vue
+++ b/cocotalk/src/views/ChatRoom.vue
@@ -53,7 +53,7 @@
     <!-- <button @click="changeNow">kkk</button> -->
     {{ roomStatus }}
     <div class="message-input-container row">
-      <textarea v-model="message"></textarea>
+      <textarea v-model="message" @keypress.enter="send"></textarea>
       <div @click="send">
         <Button text="전송" width="50px" height="30px" style="margin-top: 15px; margin-left: 16px" />
       </div>
@@ -239,7 +239,7 @@ export default {
         const msg = {
           type: 0,
           content: this.message,
-          roomId: this.roomStatus.id,
+          roomId: this.roomStatus.roomId,
           roomType: this.roomInfo.type,
           roomname: this.roomInfo.roomname,
           userId: this.userInfo.id,

--- a/cocotalk/src/views/ChatRoom.vue
+++ b/cocotalk/src/views/ChatRoom.vue
@@ -25,12 +25,13 @@
           <!-- {{ chatMessage }} -->
           <!-- 상대가 한 말 -->
           <div v-if="chatMessage.userId != userInfo.id" class="row">
-            <!-- <ProfileImg :imgUrl="chatMessage.userInfo.profile" width="40px" /> -->
+            <ProfileImg :imgUrl="profileImg(chatMessage.userId)" width="40px" />
             <div class="chat-message">
-              <!-- <div style="padding-bottom: 7px">{{ chatMessage.userInfo.userName }}</div> -->
+              <div style="padding-bottom: 7px">{{ sentUserName(chatMessage.userId) }}</div>
               <div class="row">
                 <div class="bubble box">{{ chatMessage.content }}</div>
                 <div style="position: relative; width: 70px">
+                  <div class="unread-number">2</div>
                   <div class="sent-time">오후2:00</div>
                 </div>
               </div>
@@ -41,6 +42,7 @@
             <div class="chat-message">
               <div class="row">
                 <div style="position: relative; width: 55px">
+                  <div class="unread-number-me">2</div>
                   <div class="sent-time-me">오후2:00</div>
                 </div>
                 <div class="bubble-me box">{{ chatMessage.content }}</div>
@@ -50,10 +52,9 @@
         </div>
       </div>
     </div>
-    <!-- <button @click="changeNow">kkk</button> -->
-    {{ roomStatus }}
     <div class="message-input-container row">
-      <textarea v-model="message" @keypress.enter="send"></textarea>
+      <!-- <input v-model.trim="message" type="textarea" @keypress.enter="send" /> -->
+      <textarea v-model.trim="message" @keypress.enter="send"></textarea>
       <div @click="send">
         <Button text="전송" width="50px" height="30px" style="margin-top: 15px; margin-left: 16px" />
       </div>
@@ -64,7 +65,7 @@
 
 <script>
 import { mapMutations, mapState } from "vuex";
-// import ProfileImg from "../components/common/ProfileImg.vue";
+import ProfileImg from "../components/common/ProfileImg.vue";
 import Button from "../components/common/Button.vue";
 import Sidebar from "../components/chat/Sidebar.vue";
 import Stomp from "webstomp-client";
@@ -83,7 +84,7 @@ export default {
     };
   },
   components: {
-    // ProfileImg,
+    ProfileImg,
     Button,
     Sidebar,
   },
@@ -100,6 +101,7 @@ export default {
     this.chatRoomConnect();
     this.getChat();
   },
+
   mounted() {
     console.log("채팅연결시작");
     console.log(this.roomId);
@@ -171,19 +173,34 @@ export default {
       axios.get(`chat/rooms/${this.roomStatus.roomId}/tail?count=${this.chatInfo.recentMessageBundleCount}`).then((res) => {
         console.log("채팅내역 가져오기");
         let chatData = res.data.data;
+        this.roomInfo = chatData.room;
         this.chatMessages = chatData.messageList;
         chatData.room.messageBundleIds = chatData.room.messageBundleIds.slice(1, -1).split(", ");
-        this.roomInfo = chatData.room;
         // 새로 받은 최신 bundleId 업데이트
         const payload = {
           nextMessageBundleId: this.roomInfo.messageBundleIds[this.roomInfo.messageBundleIds.length - 1],
         };
         this.$store.dispatch("chat/updateMessageBundleId", payload, { root: true });
-        let members = chatData.room.members;
-        members.forEach((e) => {
+        // 이후 메세지 보낼때 필요한 룸멤버의 아이디 값 계산
+        this.roomInfo.members.forEach((e) => {
           this.roomMemberIds.push(e.userId);
+          if (e.profile) {
+            e.profile = JSON.parse(e.profile);
+          }
         });
       });
+    },
+    sentUserName(userId) {
+      const idx = this.roomInfo.members.findIndex(function (item) {
+        return item.userId == userId;
+      });
+      return this.roomInfo.members[idx].username;
+    },
+    profileImg(userId) {
+      const idx = this.roomInfo.members.findIndex(function (item) {
+        return item.userId == userId;
+      });
+      return this.roomInfo.members[idx].profile.profile;
     },
     chatRoomConnect: function () {
       const serverURL = "http://138.2.93.111:8080/stomp";
@@ -212,6 +229,7 @@ export default {
           this.stompChatRoomClient.subscribe(`/topic/${this.roomStatus.roomId}/room`, (res) => {
             console.log("구독으로 받은 채팅방 정보입니다.");
             this.roomInfo = JSON.parse(res.body);
+            console.log(this.roomInfo);
           });
           // 채팅방 초대 - 이전의 Join과 다름. 좀 더 생각해보기
           // const msg = {
@@ -235,7 +253,7 @@ export default {
     },
     send() {
       console.log("Send message");
-      if (this.stompChatRoomClient && this.stompChatRoomClient.connected) {
+      if (this.stompChatRoomClient && this.stompChatRoomClient.connected && this.message) {
         const msg = {
           type: 0,
           content: this.message,
@@ -249,6 +267,10 @@ export default {
         };
         this.stompChatRoomClient.send(`/simple/chatroom/${this.roomStatus.roomId}/message/send`, JSON.stringify(msg));
       }
+      this.message = "";
+      // [메세지보낸 후 엔터커서 위로 올라오지 않는 현상 해결중]
+      // e.target.value = "";
+      // document.getElementById("textarea").focus();
     },
   },
 };
@@ -272,7 +294,7 @@ export default {
   overflow: auto;
 }
 .chat-messages-container {
-  height: 70vh;
+  height: 71vh;
 }
 .chat-messages-outer-container::-webkit-scrollbar {
   position: absolute;
@@ -313,7 +335,7 @@ export default {
   /* -moz-border-radius: 10px; */
   border-radius: 5px;
   margin-right: 5px;
-  max-width: 300px;
+  max-width: 250px;
   word-break: break-all;
 }
 
@@ -329,20 +351,39 @@ export default {
   left: -11px;
   top: 8px;
 }
+.unread-number {
+  color: #749f58;
+  font-size: 10px;
+  position: absolute;
+  bottom: 10px;
+  left: 1px;
+  width: 70px;
+  height: 15px;
+}
+.unread-number-me {
+  color: #749f58;
+  font-size: 10px;
+  position: absolute;
+  bottom: 10px;
+  right: 1px;
+  width: 12px;
+  height: 15px;
+}
 .sent-time {
   position: absolute;
   bottom: 0;
   right: 0;
   width: 70px;
   height: 15px;
-  font-size: 12px;
+  font-size: 11px;
 }
 .sent-time-me {
   position: absolute;
-  bottom: 0;
-  left: 0;
+  bottom: 2px;
+  right: 0;
+  width: 50px;
   height: 15px;
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .bubble-me {

--- a/cocotalk/src/views/ChatRoomList.vue
+++ b/cocotalk/src/views/ChatRoomList.vue
@@ -11,12 +11,13 @@
         </div>
       </div>
     </div>
-    <div class="chat-room-list-container">
-      <div class="chat-room-item-container row" v-for="(chat, idx) in chats" :key="idx">
+    <!-- <div class="chat-room-list-container"> -->
+    <transition-group class="chat-room-list-container" @before-enter="beforeEnter" @after-enter="afterEnter" @enter-cancelled="afterEnter">
+      <div class="chat-room-item-container row" v-for="(chat, idx) in chats" :key="chat.room.id" :data-index="idx">
         <!-- <div>
 					<ProfileImg :imgUrl="chat.img" width="50px" />
 				</div> -->
-        <button @click="deleteMessage(chat.room.id)">ddd</button>
+        <!-- <button @click="deleteMessage(chat.room.id)">ddd</button> -->
 
         <div style="dispaly: inline-block; text-align: center">
           <div v-if="chat.room.members.length == 1">
@@ -57,7 +58,8 @@
           </div>
         </div>
       </div>
-    </div>
+    </transition-group>
+    <!-- </div> -->
     {{ roomStatus }}
   </div>
 </template>
@@ -91,15 +93,36 @@ export default {
     ...mapState("socket", ["stompChatListClient", "stompChatListConnected"]),
   },
   methods: {
+    clone(o) {
+      var result = {};
+      for (var i in o) {
+        result[i] = o[i];
+      }
+      return result;
+    },
     chatListSubscribe() {
       this.stompChatListClient.subscribe(`/topic/${this.userInfo.id}/message`, (res) => {
         console.log("구독으로 받은 메시지목록의 마지막 메세지 정보 입니다.");
         const data = JSON.parse(res.body);
         let lastMessage = data.message;
-        // let nextMessageBundleId = data.bundleInfo.nextMessageBundleId;
-        // this.
+        let bundleInfo = data.bundleInfo;
+        const idx = this.chats.findIndex(function (item) {
+          return item.room.id == lastMessage.roomId;
+        });
+        console.log(idx);
+        this.chats[idx].recentChatMessage = lastMessage;
+        if (idx) {
+          console.log("화이팅");
+          const updateData = this.chats[idx];
+          console.log(updateData);
+          this.chats.splice(idx, 1);
+          this.chats.unshift(updateData);
+        }
 
+        const recentMessageBundleCount = bundleInfo.currentMessageBundleCount;
+        this.$store.dispatch("chat/updateMessageBundleCount", recentMessageBundleCount, { root: true });
         console.log(lastMessage);
+        console.log(bundleInfo);
       });
       // 채팅목록 채팅방정보 채널 subscribe
       this.stompChatListClient.subscribe(`/topic/${this.userInfo.id}/room`, (res) => {
@@ -116,7 +139,8 @@ export default {
       this.$store.dispatch("modal/openChatCreationModal", "open", { root: true });
     },
     goChat(chat) {
-      // 현재 swagger로 채팅방생성중이기때문에 nextMessageBundleId 업데이트. 이후에는 필요없음
+      // 현재 swagger로 채팅방생성중이기때문에 첫메세지가 없는 경우가 있어 nextMessageBundleId 업데이트.
+      // 채팅방내부에서 채팅내역불러와서 갱신해주기 때문에 이후에는 필요없음
       let payload = {
         roomId: chat.room.id,
         nextMessageBundleId: chat.room.messageBundleIds[chat.room.messageBundleIds.length - 1],
@@ -153,6 +177,22 @@ export default {
       console.log(idx);
       this.chats.splice(idx, 1);
       console.log(this.chats);
+    },
+    // 트랜지션 시작에서 인덱스*100ms 만큼의 딜레이 부여
+    beforeEnter(el) {
+      this.$nextTick(() => {
+        if (!this.addEnter) {
+          // 추가가 아니라면 딜레이 적용
+          el.style.transitionDelay = 100 * parseInt(el.dataset.index, 10) + "ms";
+        } else {
+          // 추가라면 플래그 제거만
+          this.addEnter = false;
+        }
+      });
+    },
+    // 트랜지션을 완료하거나 취소할 때는 딜레이를 제거합니다.
+    afterEnter(el) {
+      el.style.transitionDelay = "";
     },
   },
 };
@@ -297,5 +337,19 @@ export default {
   position: relative;
   top: -8px;
   left: -7px;
+}
+/* 트랜지션 전용 스타일 */
+.v-enter-active,
+.v-leave-active,
+.v-move {
+  transition: opacity 0.5s, transform 0.5s;
+}
+.v-leave-active {
+  position: absolute;
+}
+
+.v-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
 }
 </style>

--- a/cocotalk/src/views/ChatRoomList.vue
+++ b/cocotalk/src/views/ChatRoomList.vue
@@ -54,7 +54,7 @@
           <chat-list-info :chatInfo="chat" />
           <div class="box row chat-detail-info">
             <div class="received-time">{{ messageSentTime(chat.recentChatMessage.sentAt) }}</div>
-            <div class="message-cnt box">{{ chat.unreadNumber }}</div>
+            <div v-show="chat.unreadNumber" class="message-cnt box">{{ chat.unreadNumber }}</div>
           </div>
         </div>
       </div>
@@ -111,6 +111,10 @@ export default {
         });
         console.log(idx);
         this.chats[idx].recentChatMessage = lastMessage;
+        // 현재 입장한 방이 아니라면 안읽은메세지수에 더해줌
+        if (this.chats[idx].room.id != this.roomStatus.roomId) {
+          this.chats[idx].unreadNumber++;
+        }
         if (idx) {
           console.log("화이팅");
           const updateData = this.chats[idx];
@@ -147,6 +151,10 @@ export default {
         recentMessageBundleCount: chat.recentMessageBundleCount,
       };
       this.$store.dispatch("chat/goChat", payload, { root: true });
+      const idx = this.chats.findIndex(function (item) {
+        return item.room.id == chat.room.id;
+      });
+      this.chats[idx].unreadNumber = 0;
     },
     messageSentTime(time) {
       return this.$moment(time).format("LT");

--- a/cocotalk/src/views/ChatRoomList.vue
+++ b/cocotalk/src/views/ChatRoomList.vue
@@ -94,7 +94,12 @@ export default {
     chatListSubscribe() {
       this.stompChatListClient.subscribe(`/topic/${this.userInfo.id}/message`, (res) => {
         console.log("구독으로 받은 메시지목록의 마지막 메세지 정보 입니다.");
-        console.log(res);
+        const data = JSON.parse(res.body);
+        let lastMessage = data.message;
+        // let nextMessageBundleId = data.bundleInfo.nextMessageBundleId;
+        // this.
+
+        console.log(lastMessage);
       });
       // 채팅목록 채팅방정보 채널 subscribe
       this.stompChatListClient.subscribe(`/topic/${this.userInfo.id}/room`, (res) => {
@@ -111,6 +116,7 @@ export default {
       this.$store.dispatch("modal/openChatCreationModal", "open", { root: true });
     },
     goChat(chat) {
+      // 현재 swagger로 채팅방생성중이기때문에 nextMessageBundleId 업데이트. 이후에는 필요없음
       let payload = {
         roomId: chat.room.id,
         nextMessageBundleId: chat.room.messageBundleIds[chat.room.messageBundleIds.length - 1],


### PR DESCRIPTION
- [x] New Feature
- [x] 버그 수정
- [ ] 그 외

## 설명(Description)
* 채팅방 목록 실시간 메세지오면 채팅방 입장전까지 읽은 숫자 +1되도록 구현
* 채팅방 실시간 최근 메세지가 온 방이 맨위로 가도록 구현
* 채팅방 내부 프로필사진 룸정보와 연결해 연동되도록 반영
* 채팅방 내부 안읽은 사람 숫자 UI구현
* 엔터로 메세지 보내기구현
* 메세지 보낸후 메세지 초기화구현

## 이슈
* 채팅방목록에서 REST로 데이터 받아올때 안읽은 메세지수가 2배되는 이슈 아직 고쳐지지 않았습니다
* 채팅방 내부에서 엔터로 메세지 보내고 커서가 위로 올라가지 않음